### PR TITLE
Fix file_share.py

### DIFF
--- a/plugins/utilities.json
+++ b/plugins/utilities.json
@@ -477,6 +477,7 @@
         }
       ],
       "versions": {
+        "1.0.1": null,
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "dbd41c4",

--- a/plugins/utilities/file_share.py
+++ b/plugins/utilities/file_share.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 app = _babase.app
 
-MODS_DIR = app.python_directory_user
+MODS_DIR = app.env.python_directory_user
 REPLAYS_DIR = bui.get_replays_dir()
 HEADERS = {
     'accept': 'application/json',


### PR DESCRIPTION
Fixes the following error:
`  File "/storage/emulated/0/Android/data/net.froemling.bombsquad/files/mods/file_share.py", line 36, in <module>
    MODS_DIR = app.python_directory_user
               ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'App' object has no attribute 'python_directory_user'`