### PR TITLE
Update icons_keyboard for newer version support

### DIFF
--- a/plugins/utilities.json
+++ b/plugins/utilities.json
@@ -607,7 +607,12 @@
         }
       ],
       "versions": {
-        "3.0.1": null,
+        "3.0.1": {
+          "api_version": 8,
+          "commit_sha": "2514185",
+          "released_on": "23-12-2023",
+          "md5sum": "7af316eea124402afbf1cd79dd31f9f2"
+        },
         "3.0.0": {
           "api_version": 8,
           "commit_sha": "02da437",

--- a/plugins/utilities.json
+++ b/plugins/utilities.json
@@ -607,6 +607,7 @@
         }
       ],
       "versions": {
+        "3.0.1": null,
         "3.0.0": {
           "api_version": 8,
           "commit_sha": "02da437",

--- a/plugins/utilities/icons_keyboard.py
+++ b/plugins/utilities/icons_keyboard.py
@@ -9,6 +9,7 @@
 
 # ba_meta require api 8
 
+import bauiv1
 import babase
 from babase import charstr
 
@@ -20,15 +21,29 @@ for i in range(26 - (len(list_of_icons) % 26)):
     list_of_icons.append('‎')
 
 
+if hasattr(bauiv1, 'Keyboard'):
+# ba_meta export bauiv1.Keyboard
+    class IconKeyboard(bauiv1.Keyboard):
+        """Keyboard go brrrrrrr"""
+        name = 'Icons by \ue048Freaku'
+        chars = [(list_of_icons[0:10]),
+                 (list_of_icons[10:19]),
+                 (list_of_icons[19:26])]
+        nums = ['‎' for i in range(26)]
+        pages = {
+            f'icon{i//26+1}': tuple(list_of_icons[i:i+26])
+            for i in range(26, len(list_of_icons), 26)
+        }
+else:
 # ba_meta export keyboard
-class IconKeyboard(babase.Keyboard):
-    """Keyboard go brrrrrrr"""
-    name = 'Icons by \ue048Freaku'
-    chars = [(list_of_icons[0:10]),
-             (list_of_icons[10:19]),
-             (list_of_icons[19:26])]
-    nums = ['‎' for i in range(26)]
-    pages = {
-        f'icon{i//26+1}': tuple(list_of_icons[i:i+26])
-        for i in range(26, len(list_of_icons), 26)
-    }
+    class IconKeyboard(babase.Keyboard):
+        """Keyboard go brrrrrrr"""
+        name = 'Icons by \ue048Freaku'
+        chars = [(list_of_icons[0:10]),
+                 (list_of_icons[10:19]),
+                 (list_of_icons[19:26])]
+        nums = ['‎' for i in range(26)]
+        pages = {
+            f'icon{i//26+1}': tuple(list_of_icons[i:i+26])
+            for i in range(26, len(list_of_icons), 26)
+        }

--- a/plugins/utilities/icons_keyboard.py
+++ b/plugins/utilities/icons_keyboard.py
@@ -22,7 +22,7 @@ for i in range(26 - (len(list_of_icons) % 26)):
 
 
 if hasattr(bauiv1, 'Keyboard'):
-# ba_meta export bauiv1.Keyboard
+    # ba_meta export bauiv1.Keyboard
     class IconKeyboard(bauiv1.Keyboard):
         """Keyboard go brrrrrrr"""
         name = 'Icons by \ue048Freaku'
@@ -35,7 +35,7 @@ if hasattr(bauiv1, 'Keyboard'):
             for i in range(26, len(list_of_icons), 26)
         }
 else:
-# ba_meta export keyboard
+    # ba_meta export keyboard
     class IconKeyboard(babase.Keyboard):
         """Keyboard go brrrrrrr"""
         name = 'Icons by \ue048Freaku'


### PR DESCRIPTION
Side effects include a error log on new version (1.7.30+):
```metascan: icons_keyboard.py:38: '# ba_meta export keyboard' tag should be replaced by '# ba_meta export bauiv1.Keyboard'.```