### PR TITLE
Update some gamemodes for co-op support

### DIFF
--- a/plugins/minigames.json
+++ b/plugins/minigames.json
@@ -1093,7 +1093,12 @@
         }
       ],
       "versions": {
-        "1.0.1": null,
+        "1.0.1": {
+          "api_version": 8,
+          "commit_sha": "9ca6039",
+          "released_on": "15-02-2024",
+          "md5sum": "cb4698e70fd94402eca199250564ffba"
+        },
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "718039b",
@@ -1132,7 +1137,12 @@
         }
       ],
       "versions": {
-        "1.0.1": null,
+        "1.0.1": {
+          "api_version": 8,
+          "commit_sha": "9ca6039",
+          "released_on": "15-02-2024",
+          "md5sum": "9072f98eef0739474b2839a0866be969"
+        },
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "4941d0c",
@@ -1190,7 +1200,12 @@
         }
       ],
       "versions": {
-        "1.0.1": null,
+        "1.0.1": {
+          "api_version": 8,
+          "commit_sha": "9ca6039",
+          "released_on": "15-02-2024",
+          "md5sum": "209ddaa4c4e128650730771db4d0588c"
+        },
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "5063690",
@@ -1286,7 +1301,12 @@
         }
       ],
       "versions": {
-        "1.0.1": null,
+        "1.0.1": {
+          "api_version": 8,
+          "commit_sha": "9ca6039",
+          "released_on": "15-02-2024",
+          "md5sum": "4d711d5eb874cd63a81e9499abb74dd1"
+        },
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "ec6286e",
@@ -1306,7 +1326,12 @@
         }
       ],
       "versions": {
-        "1.0.1": null,
+        "1.0.1": {
+          "api_version": 8,
+          "commit_sha": "9ca6039",
+          "released_on": "15-02-2024",
+          "md5sum": "1e74b3d2e38ac310a1b3fc28e13833dd"
+        },
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "5063690",

--- a/plugins/minigames.json
+++ b/plugins/minigames.json
@@ -1083,7 +1083,7 @@
       }
     },
     "you_vs_bombsquad": {
-      "description": "You against bombsquad solo or with friends",
+      "description": "You against bombsquad solo or with friends. Playable in co-op",
       "external_url": "",
       "authors": [
         {
@@ -1093,6 +1093,7 @@
         }
       ],
       "versions": {
+        "1.0.1": null,
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "718039b",
@@ -1121,7 +1122,7 @@
       }
     },
     "lame_fight": {
-      "description": "Save World With Super Powers",
+      "description": "Save World With Super Powers. Playable in co-op",
       "external_url": "",
       "authors": [
         {
@@ -1131,6 +1132,7 @@
         }
       ],
       "versions": {
+        "1.0.1": null,
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "4941d0c",
@@ -1178,7 +1180,7 @@
       }
     },
     "bot_chase": {
-      "description": "Try to survive from bots!",
+      "description": "Try to survive from bots! Playable in co-op",
       "external_url": "",
       "authors": [
         {
@@ -1188,6 +1190,7 @@
         }
       ],
       "versions": {
+        "1.0.1": null,
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "5063690",
@@ -1273,7 +1276,7 @@
       }
     },
     "explodo_run": {
-      "description": "Cursed meteor shower of crazy Captain Jack trying take your soul",
+      "description": "Cursed meteor shower of crazy Captain Jack trying take your soul. Playable in co-op",
       "external_url": "",
       "authors": [
         {
@@ -1283,6 +1286,7 @@
         }
       ],
       "versions": {
+        "1.0.1": null,
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "ec6286e",
@@ -1292,7 +1296,7 @@
       }
     },
     "extinction": {
-      "description": "Survive the Extinction.",
+      "description": "Survive the Extinction. Playable in co-op",
       "external_url": "",
       "authors": [
         {
@@ -1302,6 +1306,7 @@
         }
       ],
       "versions": {
+        "1.0.1: null,"
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "5063690",

--- a/plugins/minigames.json
+++ b/plugins/minigames.json
@@ -1306,7 +1306,7 @@
         }
       ],
       "versions": {
-        "1.0.1: null,"
+        "1.0.1": null,
         "1.0.0": {
           "api_version": 8,
           "commit_sha": "5063690",

--- a/plugins/minigames/bot_chase.py
+++ b/plugins/minigames/bot_chase.py
@@ -217,6 +217,6 @@ class plugin(babase.Plugin):
     def __init__(self):
         ## Campaign support ##
         babase.app.classic.add_coop_practice_level(bs.Level(
-            name = 'Bot Chase', gametype=BotChaseGame,
+            name='Bot Chase', gametype=BotChaseGame,
             settings={},
             preview_texture_name='footballStadiumPreview'))

--- a/plugins/minigames/bot_chase.py
+++ b/plugins/minigames/bot_chase.py
@@ -16,17 +16,6 @@ if TYPE_CHECKING:
     from typing import Any, List, Type, Optional
 
 
-def ba_get_api_version():
-    return 8
-
-
-def ba_get_levels():
-    return [bs._level.Level(
-            'Bot Chase', gametype=BotChaseGame,
-            settings={},
-            preview_texture_name='footballStadiumPreview')]
-
-
 class Player(bs.Player['Team']):
     """Our player type for this game"""
 
@@ -221,3 +210,13 @@ class BotChaseGame(bs.TeamGameActivity[Player, Team]):
             results.set_team_score(team, int(1000.0 * longest_life))
 
         self.end(results=results)
+
+
+# ba_meta export plugin
+class plugin(babase.Plugin):
+    def __init__(self):
+        ## Campaign support ##
+        babase.app.classic.add_coop_practice_level(bs.Level(
+            name = 'Bot Chase', gametype=BotChaseGame,
+            settings={},
+            preview_texture_name='footballStadiumPreview'))

--- a/plugins/minigames/explodo_run.py
+++ b/plugins/minigames/explodo_run.py
@@ -18,22 +18,6 @@ if TYPE_CHECKING:
     from typing import Any, Type, Dict, List, Optional
 
 
-def ba_get_api_version():
-    return 8
-
-
-def ba_get_levels():
-    return [bs._level.Level(
-        'Explodo Run',
-        gametype=ExplodoRunGame,
-        settings={},
-        preview_texture_name='rampagePreview'), bs._level.Level(
-        'Epic Explodo Run',
-        gametype=ExplodoRunGame,
-        settings={'Epic Mode': True},
-        preview_texture_name='rampagePreview')]
-
-
 class Player(bs.Player['Team']):
     """Our player type for this game."""
 
@@ -142,3 +126,18 @@ class ExplodoRunGame(bs.TeamGameActivity[Player, Team]):
 
         # Ends the activity.
         self.end(results)
+
+
+# ba_meta export plugin
+class plugin(babase.Plugin):
+    def __init__(self):
+        ## Campaign support ##
+        babase.app.classic.add_coop_practice_level(bs.Level(
+            name = 'Explodo Run',
+        gametype=ExplodoRunGame,
+        settings={},
+        preview_texture_name='rampagePreview'))
+        babase.app.classic.add_coop_practice_level(bs.Level('Epic Explodo Run',
+        gametype=ExplodoRunGame,
+        settings={'Epic Mode': True},
+        preview_texture_name='rampagePreview'))

--- a/plugins/minigames/explodo_run.py
+++ b/plugins/minigames/explodo_run.py
@@ -133,11 +133,11 @@ class plugin(babase.Plugin):
     def __init__(self):
         ## Campaign support ##
         babase.app.classic.add_coop_practice_level(bs.Level(
-            name = 'Explodo Run',
-        gametype=ExplodoRunGame,
-        settings={},
-        preview_texture_name='rampagePreview'))
+            name='Explodo Run',
+            gametype=ExplodoRunGame,
+            settings={},
+            preview_texture_name='rampagePreview'))
         babase.app.classic.add_coop_practice_level(bs.Level('Epic Explodo Run',
-        gametype=ExplodoRunGame,
-        settings={'Epic Mode': True},
-        preview_texture_name='rampagePreview'))
+                                                            gametype=ExplodoRunGame,
+                                                            settings={'Epic Mode': True},
+                                                            preview_texture_name='rampagePreview'))

--- a/plugins/minigames/extinction.py
+++ b/plugins/minigames/extinction.py
@@ -245,11 +245,11 @@ class plugin(babase.Plugin):
     def __init__(self):
         ## Campaign support ##
         babase.app.classic.add_coop_practice_level(bs.Level(
-            name = 'Extinction',
+            name='Extinction',
             gametype=NewMeteorShowerGame,
             settings={'Epic Mode': False},
             preview_texture_name='footballStadiumPreview'))
         babase.app.classic.add_coop_practice_level(bs.Level('Epic Extinction',
-            gametype=NewMeteorShowerGame,
-            settings={'Epic Mode': True},
-            preview_texture_name='footballStadiumPreview'))
+                                                            gametype=NewMeteorShowerGame,
+                                                            settings={'Epic Mode': True},
+                                                            preview_texture_name='footballStadiumPreview'))

--- a/plugins/minigames/extinction.py
+++ b/plugins/minigames/extinction.py
@@ -18,23 +18,6 @@ if TYPE_CHECKING:
     from typing import Any, Sequence, Optional, Type
 
 
-def ba_get_api_version():
-    return 8
-
-
-def ba_get_levels():
-    return [bs._level.Level(
-            'Extinction',
-            gametype=NewMeteorShowerGame,
-            settings={'Epic Mode': False},
-            preview_texture_name='footballStadiumPreview'),
-            bs._level.Level(
-            'Epic Extinction',
-            gametype=NewMeteorShowerGame,
-            settings={'Epic Mode': True},
-            preview_texture_name='footballStadiumPreview')]
-
-
 class Meteor(bs.Actor):
     """A giant meteor instead of bombs."""
 
@@ -255,3 +238,18 @@ class NewMeteorShowerGame(bs.TeamGameActivity[Player, Team]):
             results.set_team_score(team, int(1000.0 * longest_life))
 
         self.end(results=results)
+
+
+# ba_meta export plugin
+class plugin(babase.Plugin):
+    def __init__(self):
+        ## Campaign support ##
+        babase.app.classic.add_coop_practice_level(bs.Level(
+            name = 'Extinction',
+            gametype=NewMeteorShowerGame,
+            settings={'Epic Mode': False},
+            preview_texture_name='footballStadiumPreview'))
+        babase.app.classic.add_coop_practice_level(bs.Level('Epic Extinction',
+            gametype=NewMeteorShowerGame,
+            settings={'Epic Mode': True},
+            preview_texture_name='footballStadiumPreview'))

--- a/plugins/minigames/lame_fight.py
+++ b/plugins/minigames/lame_fight.py
@@ -163,7 +163,7 @@ class plugin(babase.Plugin):
     def __init__(self):
         ## Campaign support ##
         babase.app.classic.add_coop_practice_level(bs.Level(
-            name = 'Lame Fight',
+            name='Lame Fight',
             gametype=LameFightGame,
             settings={},
             preview_texture_name='courtyardPreview'))

--- a/plugins/minigames/lame_fight.py
+++ b/plugins/minigames/lame_fight.py
@@ -18,18 +18,6 @@ if TYPE_CHECKING:
     from typing import Any, Type, Dict, List, Optional
 
 
-def ba_get_api_version():
-    return 6
-
-
-def ba_get_levels():
-    return [babase._level.Level(
-        'Lame Fight',
-        gametype=LameFightGame,
-        settings={},
-        preview_texture_name='courtyardPreview')]
-
-
 class Player(bs.Player['Team']):
     """Our player type for this game."""
 
@@ -168,3 +156,14 @@ class LameFightGame(bs.TeamGameActivity[Player, Team]):
 
         # Ends the activity.
         self.end(results)
+
+
+# ba_meta export plugin
+class plugin(babase.Plugin):
+    def __init__(self):
+        ## Campaign support ##
+        babase.app.classic.add_coop_practice_level(bs.Level(
+            name = 'Lame Fight',
+            gametype=LameFightGame,
+            settings={},
+            preview_texture_name='courtyardPreview'))

--- a/plugins/minigames/you_vs_bombsquad.py
+++ b/plugins/minigames/you_vs_bombsquad.py
@@ -483,23 +483,23 @@ class plugin(babase.Plugin):
     def __init__(self):
         ## Campaign support ##
         babase.app.classic.add_coop_practice_level(bs.Level(
-            name = name_easy,
-        gametype=TUvsBombSquad,
-        settings={},
-        preview_texture_name='footballStadiumPreview'))
+            name=name_easy,
+            gametype=TUvsBombSquad,
+            settings={},
+            preview_texture_name='footballStadiumPreview'))
         babase.app.classic.add_coop_practice_level(bs.Level(
-        name_easy_epic,
-        gametype=TUvsBombSquad,
-        settings={'Epic Mode': True},
-        preview_texture_name='footballStadiumPreview'))
+            name_easy_epic,
+            gametype=TUvsBombSquad,
+            settings={'Epic Mode': True},
+            preview_texture_name='footballStadiumPreview'))
         babase.app.classic.add_coop_practice_level(bs.Level(
-            name = name_hard,
-        gametype=TUvsBombSquad,
-        settings={'Hard Mode': True},
-        preview_texture_name='footballStadiumPreview'))
+            name=name_hard,
+            gametype=TUvsBombSquad,
+            settings={'Hard Mode': True},
+            preview_texture_name='footballStadiumPreview'))
         babase.app.classic.add_coop_practice_level(bs.Level(
-            name = name_hard_epic,
-        gametype=TUvsBombSquad,
-        settings={'Hard Mode': True,
-                  'Epic Mode': True},
-        preview_texture_name='footballStadiumPreview'))
+            name=name_hard_epic,
+            gametype=TUvsBombSquad,
+            settings={'Hard Mode': True,
+                      'Epic Mode': True},
+            preview_texture_name='footballStadiumPreview'))

--- a/plugins/minigames/you_vs_bombsquad.py
+++ b/plugins/minigames/you_vs_bombsquad.py
@@ -33,33 +33,6 @@ else:
     name_hard = 'You vs BS Hard'
     name_hard_epic = 'You vs BS Hard Epic'
 
-# def ba_get_api_version():
-#     return 6
-
-
-def ba_get_levels():
-    return [babase._level.Level(
-        name_easy,
-        gametype=TUvsBombSquad,
-        settings={},
-        preview_texture_name='footballStadiumPreview'),
-        babase._level.Level(
-        name_easy_epic,
-        gametype=TUvsBombSquad,
-        settings={'Epic Mode': True},
-        preview_texture_name='footballStadiumPreview'),
-
-        babase._level.Level(
-        name_hard,
-        gametype=TUvsBombSquad,
-        settings={'Hard Mode': True},
-        preview_texture_name='footballStadiumPreview'),
-        babase._level.Level(
-        name_hard_epic,
-        gametype=TUvsBombSquad,
-        settings={'Hard Mode': True,
-                  'Epic Mode': True},
-        preview_texture_name='footballStadiumPreview')]
 
 #### BOTS ####
 
@@ -503,3 +476,30 @@ class TUvsBombSquad(bs.TeamGameActivity[Player, Team]):
 
         # Ends the activity.
         self.end(results)
+
+
+# ba_meta export plugin
+class plugin(babase.Plugin):
+    def __init__(self):
+        ## Campaign support ##
+        babase.app.classic.add_coop_practice_level(bs.Level(
+            name = name_easy,
+        gametype=TUvsBombSquad,
+        settings={},
+        preview_texture_name='footballStadiumPreview'))
+        babase.app.classic.add_coop_practice_level(bs.Level(
+        name_easy_epic,
+        gametype=TUvsBombSquad,
+        settings={'Epic Mode': True},
+        preview_texture_name='footballStadiumPreview'))
+        babase.app.classic.add_coop_practice_level(bs.Level(
+            name = name_hard,
+        gametype=TUvsBombSquad,
+        settings={'Hard Mode': True},
+        preview_texture_name='footballStadiumPreview'))
+        babase.app.classic.add_coop_practice_level(bs.Level(
+            name = name_hard_epic,
+        gametype=TUvsBombSquad,
+        settings={'Hard Mode': True,
+                  'Epic Mode': True},
+        preview_texture_name='footballStadiumPreview'))


### PR DESCRIPTION
These games were made to also be played in co-op, during 1.6 Eric forgot to add the ability to register games in Campaign.
Thus, a mod was required to play such gamemodes in co-op. But thanks to now added Campaign support, there's no more need of such a mod.

This PR implements the method of registering such games in Campaign & ability to play in co-op.
![ehaha](https://github.com/bombsquad-community/plugin-manager/assets/92618708/b774aebd-3296-41d8-b10e-ba01c2fd752a)
