### PR TITLE
Wait for scene app mode to activate

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6 +1,7 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
+    "1.0.8": null,
     "1.0.7": {
       "api_version": 8,
       "commit_sha": "cf55d26",

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -32,7 +32,7 @@ from threading import Thread
 import logging
 
 
-PLUGIN_MANAGER_VERSION = "1.0.7"
+PLUGIN_MANAGER_VERSION = "1.0.8"
 REPOSITORY_URL = "https://github.com/bombsquad-community/plugin-manager"
 # Current tag can be changed to "staging" or any other branch in
 # plugin manager repo for testing purpose.

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -4,8 +4,8 @@ from baenv import TARGET_BALLISTICA_BUILD
 import babase
 import _babase
 import bauiv1 as bui
-import _bauiv1 as _bui
-import _bascenev1 as _bs
+import _bauiv1
+import _bascenev1
 from bauiv1lib import popup, confirm
 
 import urllib.request
@@ -64,11 +64,8 @@ if TARGET_BALLISTICA_BUILD < 21282:
     babase.app.env.arcade = babase.app.arcade_mode
     babase.app.env.headless = babase.app.arcade_mode
     babase.app.env.demo = babase.app.demo_mode
-    protocol_version = babase.app.protocol_version
-    toolbar_test = babase.app.toolbar_test
-else:
-    protocol_version = _bs.protocol_version()
-    toolbar_test = _bui.toolbar_test()
+    _bascenev1.protocol_version = lambda: babase.app.protocol_version
+    _bauiv1.toolbar_test = lambda: babase.app.toolbar_test
 
 
 _env = _babase.env()


### PR DESCRIPTION
Reported in ballistica's official discord server: https://discord.com/channels/1001896771347304639/1218201750440247296/1227731932838760521.

We were calling `_bascenev1.protocol_version()` before SceneAppMode was activated (by ballistica), which isn't allowed in newer ballistica versions.

It was the cause of the following traceback:
```sh
$ CMAKE_BUILD_TYPE="Debug" make prefab-gui-debug

BA_WSL_TARGETS_WINDOWS=1 tools/pcommand make_prefab gui-debug
make[1]: Entering directory '/home/rikkolovescats/ballistica'
Lazybuild: skipping "meta" (checked 89 inputs in 0.0026s).
Lazybuild: skipping "assets-cmake" (checked 376 inputs in 0.0018s).
Staging for cmake at build/prefab/full/linux_x86_64_gui/debug...
make[1]: Leaving directory '/home/rikkolovescats/ballistica'
cd build/prefab/full/linux_x86_64_gui/debug && ./ballisticakit
root: BallisticaKit 1.7.34 build 21800.
root: Error loading plugin class 'plugin_manager.EntryPoint'.
Traceback (most recent call last):
  File "/home/rikkolovescats/ballistica/build/prefab/full/linux_x86_64_gui/debug/ba_data/python/babase/_plugin.py", line 283, in attempt_load_if_enabled
    cls = getclass(self.class_path, Plugin)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rikkolovescats/ballistica/build/prefab/full/linux_x86_64_gui/debug/ba_data/python/babase/_general.py", line 83, in getclass
    module = importlib.import_module(modulename)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/rikkolovescats/.ballisticakit/mods/plugin_manager.py", line 70, in <module>
    protocol_version = _bs.protocol_version()
                       ^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Attempting to access SceneAppMode while it is inactive.
```

This commit improves the compatibility layer such that any calls that require SceneAppMode to be active aren't made before it gets active.