### PR TITLE
Improvements to the new plugins notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Plugin Manager (dd-mm-yyyy)
 
+### 1.0.13 (20-04-2024)
+
+- Improvements to the new plugins notification
+
 ### 1.0.12 (20-04-2024)
 
 - Limited the "x new plugins are available" screen message to only show maximum 3 plugins.

--- a/index.json
+++ b/index.json
@@ -1,6 +1,7 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
+    "1.0.13": null,
     "1.0.12": {
       "api_version": 8,
       "commit_sha": "34bbcba",

--- a/index.json
+++ b/index.json
@@ -1,7 +1,12 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
-    "1.0.13": null,
+    "1.0.13": {
+      "api_version": 8,
+      "commit_sha": "2a4cb47",
+      "released_on": "21-04-2024",
+      "md5sum": "0d04386a75f692bd80875c6f97b262c5"
+    },
     "1.0.12": {
       "api_version": 8,
       "commit_sha": "34bbcba",

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -31,8 +31,7 @@ from datetime import datetime
 from threading import Thread
 import logging
 
-
-PLUGIN_MANAGER_VERSION = "1.0.12"
+PLUGIN_MANAGER_VERSION = "1.0.13"
 REPOSITORY_URL = "https://github.com/bombsquad-community/plugin-manager"
 # Current tag can be changed to "staging" or any other branch in
 # plugin manager repo for testing purpose.
@@ -356,7 +355,7 @@ class StartupTasks:
     async def notify_new_plugins(self):
         if not babase.app.config["Community Plugin Manager"]["Settings"]["Notify New Plugins"]:
             return
-
+        show_max_names = 2
         await self.plugin_manager.setup_index()
         new_num_of_plugins = len(await self.plugin_manager.categories["All"].get_plugins())
         try:
@@ -380,14 +379,15 @@ class StartupTasks:
             new_supported_plugins_count = len(new_supported_plugins)
             if new_supported_plugins_count > 0:
                 new_supported_plugins = ", ".join(map(str, (new_supported_plugins
-                                                            if new_supported_plugins_count < 4 else
-                                                            new_supported_plugins[0:3])
+                                                            if new_supported_plugins_count <= show_max_names else
+                                                            new_supported_plugins[0:show_max_names])
                                                       ))
                 if new_supported_plugins_count == 1:
                     notification_text = f"{new_supported_plugins_count} new plugin ({new_supported_plugins}) is available!"
                 else:
-                    notification_text = (f"{new_supported_plugins_count} new plugins " +
-                                         f"({new_supported_plugins + (', etc' if new_supported_plugins_count > 3 else '')}) are available!")
+                    notification_text = new_supported_plugins + \
+                        ('' if new_supported_plugins_count <= show_max_names else ' and +' +
+                         str(new_supported_plugins_count-show_max_names)) + " new plugins are available"
                 bui.screenmessage(notification_text, color=(0, 1, 0))
 
         if existing_num_of_plugins != new_num_of_plugins:


### PR DESCRIPTION
Now displaying notification if format of `plugin1, plugin2, plugin3 and +2 new plugins are available` when there are more than 3 new plugins