### PR TITLE
bs 1.7.35 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### 1.0.20 (13-05-2024)
 
-- Update for bs version 1.7.35
-- Updated build_number and version attributes
+- Now compatible with BS version 1.7.35+.
+- Updated build_number and version attributes to latest.
 
 ### 1.0.19 (05-05-2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Plugin Manager (dd-mm-yyyy)
 
+### 1.0.20 (13-05-2024)
+
+- Update for bs version 1.7.35
+- Updated build_number and version attributes
+
 ### 1.0.19 (05-05-2024)
 
 - Fixed an issue where changelogs were not displayed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Now compatible with BS version 1.7.35+.
 - Updated build_number and version attributes to latest.
+- FIX: Changelog for all version was shown after refreshing
 
 ### 1.0.19 (05-05-2024)
 

--- a/index.json
+++ b/index.json
@@ -1,7 +1,12 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
-    "1.0.20": null,
+    "1.0.20": {
+      "api_version": 8,
+      "commit_sha": "f229b33",
+      "released_on": "13-05-2024",
+      "md5sum": "b66c2400458cebcbce6d282a3efef816"
+    },
     "1.0.19": {
       "api_version": 8,
       "commit_sha": "b439c4b",

--- a/index.json
+++ b/index.json
@@ -1,7 +1,12 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
-    "1.0.20": null,
+    "1.0.20": {
+      "api_version": 8,
+      "commit_sha": "5ce10ce",
+      "released_on": "13-05-2024",
+      "md5sum": "eb49f952e59effaf4529017f4bed4f72"
+    },
     "1.0.19": {
       "api_version": 8,
       "commit_sha": "b439c4b",

--- a/index.json
+++ b/index.json
@@ -1,6 +1,7 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
+    "1.0.20": null,
     "1.0.19": {
       "api_version": 8,
       "commit_sha": "b439c4b",

--- a/index.json
+++ b/index.json
@@ -1,7 +1,12 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
-    "1.0.20": null,
+    "1.0.20": {
+      "api_version": 8,
+      "commit_sha": "eab0665",
+      "released_on": "12-05-2024",
+      "md5sum": "fdabe6606c901b85b027f840a785ff16"
+    },
     "1.0.19": {
       "api_version": 8,
       "commit_sha": "b439c4b",

--- a/index.json
+++ b/index.json
@@ -1,12 +1,7 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
-    "1.0.20": {
-      "api_version": 8,
-      "commit_sha": "eab0665",
-      "released_on": "12-05-2024",
-      "md5sum": "fdabe6606c901b85b027f840a785ff16"
-    },
+    "1.0.20": null,
     "1.0.19": {
       "api_version": 8,
       "commit_sha": "b439c4b",

--- a/index.json
+++ b/index.json
@@ -1,12 +1,7 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
-    "1.0.20": {
-      "api_version": 8,
-      "commit_sha": "f229b33",
-      "released_on": "13-05-2024",
-      "md5sum": "b66c2400458cebcbce6d282a3efef816"
-    },
+    "1.0.20": null,
     "1.0.19": {
       "api_version": 8,
       "commit_sha": "b439c4b",

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -37,7 +37,7 @@ REPOSITORY_URL = "https://github.com/bombsquad-community/plugin-manager"
 # plugin manager repo for testing purpose.
 CURRENT_TAG = "main"
 
-    
+
 if TARGET_BALLISTICA_BUILD < 21282:
     # These attributes have been deprecated as of 1.7.27. For more info see:
     # https://github.com/efroemling/ballistica/blob/master/CHANGELOG.md#1727-build-21282-api-8-2023-08-30

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -38,6 +38,10 @@ REPOSITORY_URL = "https://github.com/bombsquad-community/plugin-manager"
 CURRENT_TAG = "main"
 
 
+if TARGET_BALLISTICA_BUILD < 21852:
+    babase.app.env.engine_build_number = babase.app.env.build_number
+    babase.app.env.engine_version = babase.app.env.version
+    
 if TARGET_BALLISTICA_BUILD < 21282:
     # These attributes have been deprecated as of 1.7.27. For more info see:
     # https://github.com/efroemling/ballistica/blob/master/CHANGELOG.md#1727-build-21282-api-8-2023-08-30
@@ -47,10 +51,10 @@ if TARGET_BALLISTICA_BUILD < 21282:
 
     babase.app.env = Dummy()
 
-    babase.app.env.build_number = babase.app.build_number
+    babase.app.env.engine_build_number = babase.app.build_number
     babase.app.env.device_name = babase.app.device_name
     babase.app.env.config_file_path = babase.app.config_file_path
-    babase.app.env.version = babase.app.version
+    babase.app.env.engine_version = babase.app.version
     babase.app.env.debug = babase.app.debug_build
     babase.app.env.test = babase.app.test_build
     babase.app.env.data_directory = babase.app.data_directory

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -31,7 +31,7 @@ from datetime import datetime
 from threading import Thread
 import logging
 
-PLUGIN_MANAGER_VERSION = "1.0.19"
+PLUGIN_MANAGER_VERSION = "1.0.20"
 REPOSITORY_URL = "https://github.com/bombsquad-community/plugin-manager"
 # Current tag can be changed to "staging" or any other branch in
 # plugin manager repo for testing purpose.

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -1466,6 +1466,7 @@ class PluginManager:
                 category.cleanup()
         self.categories.clear()
         self._index.clear()
+        self._changelog = None
         self.unset_index_global_cache()
 
     async def refresh(self):

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -37,13 +37,6 @@ REPOSITORY_URL = "https://github.com/bombsquad-community/plugin-manager"
 # plugin manager repo for testing purpose.
 CURRENT_TAG = "main"
 
-
-if TARGET_BALLISTICA_BUILD < 21852:
-    class Dummy(babase.app.env):
-        engine_build_number = babase.app.env.build_number
-        engine_version = babase.app.env.version
-
-    babase.app.env = Dummy
     
 if TARGET_BALLISTICA_BUILD < 21282:
     # These attributes have been deprecated as of 1.7.27. For more info see:
@@ -73,6 +66,12 @@ if TARGET_BALLISTICA_BUILD < 21282:
     _bascenev1.protocol_version = lambda: babase.app.protocol_version
     _bauiv1.toolbar_test = lambda: babase.app.toolbar_test
 
+if TARGET_BALLISTICA_BUILD < 21852:
+    class Dummy(babase.app.env):
+        engine_build_number = babase.app.env.build_number
+        engine_version = babase.app.env.version
+
+    babase.app.env = Dummy
 
 _env = _babase.env()
 _uiscale = bui.app.ui_v1.uiscale

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -39,8 +39,11 @@ CURRENT_TAG = "main"
 
 
 if TARGET_BALLISTICA_BUILD < 21852:
-    babase.app.env.engine_build_number = babase.app.env.build_number
-    babase.app.env.engine_version = babase.app.env.version
+    class Dummy(babase.app.env):
+        engine_build_number = babase.app.env.build_number
+        engine_version = babase.app.env.version
+
+    babase.app.env = Dummy
     
 if TARGET_BALLISTICA_BUILD < 21282:
     # These attributes have been deprecated as of 1.7.27. For more info see:


### PR DESCRIPTION
`babase.app.env.build_number` is now `babase.app.env.engine_build_number`
and `babase.app.env.version` is now `babase.app.env.engine_version`