### PR TITLE
fix unable to start kick vote in APW

### DIFF
--- a/plugins/utilities.json
+++ b/plugins/utilities.json
@@ -753,6 +753,7 @@
         }
       ],
       "versions": {
+        "2.1.2": null,
         "2.1.1": {
           "api_version": 9,
           "commit_sha": "a93fda3",

--- a/plugins/utilities.json
+++ b/plugins/utilities.json
@@ -753,7 +753,12 @@
         }
       ],
       "versions": {
-        "2.1.2": null,
+        "2.1.2": {
+          "api_version": 9,
+          "commit_sha": "c912759",
+          "released_on": "25-03-2025",
+          "md5sum": "1d732670a4e8b71fc0e5d9ea9b4a31b4"
+        },
         "2.1.1": {
           "api_version": 9,
           "commit_sha": "a93fda3",

--- a/plugins/utilities/advanced_party_window.py
+++ b/plugins/utilities/advanced_party_window.py
@@ -1164,7 +1164,7 @@ class ModifiedPartyWindow(bascenev1lib_party.PartyWindow):
             else:
                 # kick-votes appeared in build 14248
                 info = bs.get_connection_to_host_info_2()
-                if bool(info) and (info.get('build_number', 0) <
+                if bool(info) and (info.build_number <
                                    14248):
                     bui.getsound('error').play()
                     bs.broadcastmessage(


### PR DESCRIPTION
Fixed #356 
info.get('build_number', 0) replaced with info.build_number