### PR TITLE
The Egg Game fix

### DIFF
--- a/plugins/minigames.json
+++ b/plugins/minigames.json
@@ -1244,8 +1244,8 @@
         }
       ],
       "versions": {
-        "1.0.0": {
-          "api_version": 8,
+        "1.0.1": {
+          "api_version": 9,
           "commit_sha": "388e58a",
           "released_on": "01-02-2024",
           "md5sum": "8fc1f9c984f9e77b0125cbeaba5c13bf"

--- a/plugins/minigames/egg_game.py
+++ b/plugins/minigames/egg_game.py
@@ -1,4 +1,3 @@
-# Ported by brostos to api 8
 # Tool used to make porting easier.(https://github.com/bombsquad-community/baport)
 # Released under the MIT License. See LICENSE for details.
 
@@ -7,7 +6,7 @@
 #  created in BCS (Bombsquad Consultancy Service) - opensource bombsquad mods for all
 #  discord.gg/ucyaesh    join now and give your contribution
 #  The Egg game by mr.smoothy
-# ba_meta require api 8
+# ba_meta require api 9
 # (see https://ballistica.net/wiki/meta-tag-system)
 
 from __future__ import annotations
@@ -124,12 +123,6 @@ class EggGame(bs.TeamGameActivity[Player, Team]):
     name = 'Epic Egg Game'
     description = 'Score some goals.'
     available_settings = [
-        bs.IntSetting(
-            'Score to Win',
-            min_value=1,
-            default=1,
-            increment=1,
-        ),
         bs.IntChoiceSetting(
             'Time Limit',
             choices=[
@@ -339,7 +332,7 @@ class EggGame(bs.TeamGameActivity[Player, Team]):
 
         try:
             col = source_player.team.color
-            self.flagg = Flag(pos, touchable=False, color=col).autoretain()
+            self.flagg = Flag(touchable=False, position=pos, color=col).autoretain()
             self.flagg.is_area_of_interest = True
             player_pos = source_player.node.position
 


### PR DESCRIPTION
ported to api 9, and fixed an error when spawning the flag. (I think it rised after python update or smth and the method became wrong)

fyi I think there're a few other plugins that only need a number swap to go to api 9, and some don't even need bui but is imported.