### PR TITLE
Updated export shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Plugin Manager (dd-mm-yyyy)
 
+### 1.1.9 (11-06-2026)
+
+- Fix for bs 1.7.63
+
 ### 1.1.8 (23-02-2026)
 
 - Fix for bs 1.7.61 build no 22714

--- a/index.json
+++ b/index.json
@@ -1,6 +1,7 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
+    "1.1.9": null,
     "1.1.8": {
       "api_version": 9,
       "commit_sha": "8222081",

--- a/index.json
+++ b/index.json
@@ -1,7 +1,12 @@
 {
   "plugin_manager_url": "https://github.com/bombsquad-community/plugin-manager/{content_type}/{tag}/plugin_manager.py",
   "versions": {
-    "1.1.9": null,
+    "1.1.9": {
+      "api_version": 9,
+      "commit_sha": "3adfe38",
+      "released_on": "11-06-2026",
+      "md5sum": "d7e990ea4e5c530f780e617c9bdafb42"
+    },
     "1.1.8": {
       "api_version": 9,
       "commit_sha": "8222081",

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -26,7 +26,7 @@ from datetime import datetime
 # Modules used for overriding AllSettingsWindow
 import logging
 
-PLUGIN_MANAGER_VERSION = "1.1.8"
+PLUGIN_MANAGER_VERSION = "1.1.9"
 REPOSITORY_URL = "https://github.com/bombsquad-community/plugin-manager"
 # Current tag can be changed to "staging" or any other branch in
 # plugin manager repo for testing purpose.

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -2,7 +2,7 @@
 import babase
 import bauiv1 as bui
 from bauiv1lib import popup, confirm
-from babase._meta import EXPORT_CLASS_NAME_SHORTCUTS
+from babase._meta import _DEPRECATED_EXPORT_SHORTCUTS
 from bauiv1lib.settings.allsettings import AllSettingsWindow
 
 import urllib.request
@@ -82,7 +82,7 @@ REGEXP = {
     "plugin_entry_points": re.compile(
         bytes(
             "(ba_meta export (plugin|{})\n+class )(.*)\\(".format(
-                _regexp_friendly_class_name_shortcut(EXPORT_CLASS_NAME_SHORTCUTS["plugin"]),
+                _regexp_friendly_class_name_shortcut(_DEPRECATED_EXPORT_SHORTCUTS["plugin"]),
             ),
             "utf-8"
         ),


### PR DESCRIPTION
Replaced all instances of EXPORT_CLASS_NAME_SHORTCUTS with _DEPRECATED_EXPORT_SHORTCUTS for bs version 1.7.63