### PR TITLE
translate: repair the broken 1.1.4 catalog entry

### DIFF
--- a/plugins/utilities.json
+++ b/plugins/utilities.json
@@ -384,10 +384,11 @@
         {
           "name": "Freaku",
           "email": "",
-          "discord": ""
+          "discord": "freakyyyy"
         }
       ],
       "versions": {
+        "1.1.4": null,
         "1.1.3": {
           "api_version": 9,
           "commit_sha": "23f90dc",

--- a/plugins/utilities.json
+++ b/plugins/utilities.json
@@ -388,7 +388,12 @@
         }
       ],
       "versions": {
-        "1.1.4": null,
+        "1.1.4": {
+          "api_version": 9,
+          "commit_sha": "bf54671",
+          "released_on": "06-09-2026",
+          "md5sum": "4e150afbf00ff0341f0c7ee2cb00cedb"
+        },
         "1.1.3": {
           "api_version": 9,
           "commit_sha": "23f90dc",

--- a/plugins/utilities/translate.py
+++ b/plugins/utilities/translate.py
@@ -19,7 +19,7 @@ __author__ = "Freaku"
 
 plugman = dict(
     description="Translate yours/others chat. Just click on the message to translate them. Open Plugin Settings/Double click 'Trans' button to open translation settings. Compatible with other PW mods (like advanced_party_window)",
-    external_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    external_url="https://github.com/bombsquad-community/plugin-manager/assets/92618708/5860e44d-0b70-4a3f-a651-208a4452ea38",
     authors=[
         {"name": __author__, "email": "", "discord": "freakyyyy"}
     ],
@@ -30,6 +30,8 @@ show_translate_result = True
 config = babase.app.config
 
 # Convert Ballistica Locale -> this mod's language name.
+
+
 def get_default_translate_language():
     locale = babase.app.locale.default_locale
 
@@ -97,7 +99,6 @@ for key in ('O Target Trans Lang', 'Y Target Trans Lang'):
         config[key] = default_language
 
 
-
 # Language names -> Google Translate language codes.
 translate_languages = {
     'Auto Detect': 'auto',
@@ -148,15 +149,13 @@ available_translate_languages.remove('Auto Detect')
 available_translate_languages.insert(0, 'Auto Detect')
 
 
-
 def translate(text, _callback, source='auto', target='en'):
     try:
         text = urllib.parse.quote(text)
         url = f'https://translate.google.com/m?tl={target}&sl={source}&q={text}'
         request = urllib.request.Request(url)
         data = urllib.request.urlopen(request).read().decode('utf-8')
-        result = data[(data.find('"result-container">'))+len('"result-container">')
-                       :data.find('</div><div class="links-container">')]
+        result = data[(data.find('"result-container">'))+len('"result-container">'):data.find('</div><div class="links-container">')]
         replace_list = [('&#39;', '\''), ('&quot;', '"'), ('&amp;', '&')]
         for i in replace_list:
             result = result.replace(i[0], i[1])
@@ -186,7 +185,7 @@ class NewPW(bauiv1lib.party.PartyWindow):
 
     def _translate_your_chat(self):
         global show_translate_result
-    
+
         if (
             babase.apptime() - self._last_time_pressed_translate
             < self._double_press_interval
@@ -249,7 +248,7 @@ class NewPW(bauiv1lib.party.PartyWindow):
 
     def _translate_other(self, txt, msg):
         global show_translate_result
-    
+
         if (
             babase.apptime() - self._last_time_pressed_msg
             < self._double_press_interval
@@ -270,7 +269,7 @@ class NewPW(bauiv1lib.party.PartyWindow):
         if len(msg.split(':')) > 1:
             nickname = msg.split(':')[0] + ': '
             split_msg = ':'.join(msg.split(':')[1:])[1:]
-    
+
         def _apply_translation(translated):
             if txt.exists():
                 bui.textwidget(


### PR DESCRIPTION
`translate` is currently uninstallable from the in-game plugin manager. `plugins/utilities/translate.py` on `main` declares `1.1.4`, but `plugins/utilities.json` still tops out at `1.1.3`, so the manager offers 1.1.3, downloads 1.1.4's bytes, and rejects them on the MD5 check. `test_latest_version` fails on `main` for the same reason.

### How it got there

Two CI failures stacked on the #482 merge:

1. **PR Apply** ([run 34018273545](https://github.com/bombsquad-community/plugin-manager/actions/runs/34018273545)) could not resolve the PR from its head sha. `ci-apply.yml` uses `GET /repos/{repo}/commits/{sha}/pulls` with 5x10s of retries, and GitHub had not indexed the fork push into that endpoint in time:

   ```
   No PR associated with 76846b8... after 5 attempts.
   Formatting/metadata fixups were NOT applied to the branch.
   ```

   PR Check itself passed and uploaded `fixups.patch`; it was simply never applied.

2. **CI on main** ([run 34018360588](https://github.com/bombsquad-community/plugin-manager/actions/runs/34018360588)) would have redone that work, but its first auto-commit step cannot push:

   ```
   remote: error: GH006: Protected branch update failed for refs/heads/main.
   remote: - Changes must be made through a pull request.
   ```

   `main` requires a PR with 1 approving review and has no bypass for `github-actions[bot]`, so all three `git-auto-commit-action` steps in `ci.yml` are inert. The run died before the tests ran. This had not surfaced earlier because the last auto-commit with anything to push was 2026-08-23; every run since had a clean tree, and the action no-ops without pushing.

This is the same shape as the `8628c97` finder incident that `ci.yml`'s header comment documents.

### What this PR does

- `autopep8 --in-place --recursive --max-line-length=100 .` on `translate.py`, run with CI's pinned toolchain (`pycodestyle==2.12.1`, autopep8 2.3.2). Produces `1 file changed, 7 insertions(+), 8 deletions(-)`, matching what the failed run reported.
- `auto_apply_plugin_metadata.py` adds the `1.1.4` entry and picks up the author's discord handle.
- `auto_apply_version_metadata.py` stamps it, invoked exactly as `ci.yml` does.
- Restores `external_url` in the `plugman` dict to the demo asset the manifest has carried since 1.1.3. The dict added in ff500c0 had it pointing at `youtube.com/watch?v=dQw4w9WgXcQ`, which would have been published into the catalog API.

### Verification

```
manifest 1.1.4:     {'api_version': 9, 'commit_sha': 'bf54671',
                     'released_on': '06-09-2026',
                     'md5sum': '4e150afbf00ff0341f0c7ee2cb00cedb'}
blob md5 @ bf54671:  4e150afbf00ff0341f0c7ee2cb00cedb
```

`python -m unittest discover`: 59 tests, OK.

### Still outstanding

This restores the catalog but does not fix either workflow bug. Both need follow-ups:

- `ci.yml`'s auto-commit steps cannot push to a protected `main`. Either grant the Actions app a bypass, give the push steps a PAT/App token, or make the main-side steps verify-only and let the PR path be the sole writer.
- `ci-apply.yml`'s PR resolution should not depend on the laggy `commits/{sha}/pulls` index. Resolving by head repo+branch and then asserting `headRefOid == workflow_run.head_sha` is equally fail-closed and far more reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
