### PR TITLE
ci: run the metadata pipeline on main, and push with a PAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,9 @@ jobs:
       # only: autopep8 and GitPython are unpinned and already ran above with
       # the credential live.
       - name: Drop push credentials
-        run: git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+        run: |
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --local --unset-all "http.${GITHUB_SERVER_URL}/.extraheader" || true
 
       - name: Execute Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,26 +23,66 @@ name: CI
 # whole change, which restored the old bytes rather than recording the new
 # ones.
 #
-# The auto-commit steps below push with the default GITHUB_TOKEN, and GitHub
-# does not start a workflow run for those pushes (there is no ci.yml run for
-# b1be5d5, the "[ci] apply-formatting" commit). So this job sees each push
-# exactly once and does not re-enter itself.
+# The auto-commit steps below push with a PAT (secrets.PAT), NOT the
+# default GITHUB_TOKEN. main's "require a pull request before merging"
+# ruleset refuses GITHUB_TOKEN pushes outright:
+#
+#   remote: error: GH006: Protected branch update failed for refs/heads/main.
+#   remote: - Changes must be made through a pull request.
+#
+# That is a protection-rule rejection, not a permissions problem, so no
+# `permissions:` value can fix it - the token already had contents: write
+# when it was refused. The fix is that the PAT's account sits on that
+# ruleset's bypass list. GITHUB_TOKEN cannot be given a ruleset bypass at
+# all: bypass actors may be repository roles, teams, installed GitHub Apps
+# or Dependabot, and the built-in Actions integration is none of those.
+#
+# CONSEQUENCE, and the reason for the job-level `if:` below: unlike
+# GITHUB_TOKEN, a PAT's pushes DO start new workflow runs. Without the guard
+# this workflow re-enters itself on its own "[ci] ..." commits, forever.
+# Skipping those re-runs loses nothing, because the strict test run at the
+# end of this job already ran against the final tree it produced.
 
 on:
   push:
     branches:
       - main
 
+# Least privilege: the pushes in this job authenticate with PAT, so
+# GITHUB_TOKEN itself never needs write.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
+    # See CONSEQUENCE in the header. Do not remove without first moving the
+    # pushes back to an identity whose commits do not trigger workflows.
+    if: ${{ !startsWith(github.event.head_commit.message, '[ci] ') }}
     runs-on: ubuntu-latest
     steps:
+      # Fail fast and legibly. Without this, a missing secret surfaces as an
+      # opaque authentication error at the first auto-commit step, five steps
+      # later, which reads like a protection problem rather than a config one.
+      - name: Check PAT is configured
+        env:
+          PAT: ${{ secrets.PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PAT" ]; then
+            echo "secrets.PAT is not set." >&2
+            echo "This workflow cannot push to main without it: the branch ruleset" >&2
+            echo "rejects GITHUB_TOKEN pushes (GH006). See the header comment." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Hands the PAT to git. persist-credentials defaults to true, and
+          # that is precisely what makes the three git-auto-commit-action
+          # steps below push as the bypassing account rather than as
+          # github-actions[bot]. They need no configuration of their own.
+          token: ${{ secrets.PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,19 @@ name: CI
 #
 # CONSEQUENCE, and the reason for the job-level `if:` below: unlike
 # GITHUB_TOKEN, a PAT's pushes DO start new workflow runs. Without the guard
-# this workflow re-enters itself on its own "[ci] ..." commits, forever.
-# Skipping those re-runs loses nothing, because the strict test run at the
-# end of this job already ran against the final tree it produced.
+# this workflow re-enters itself on its own commits, forever. Skipping those
+# re-runs loses nothing, because the strict test run at the end of this job
+# already ran against the final tree it produced.
+#
+# The guard keys on the COMMITTER IDENTITY that the three auto-commit steps
+# below set, NOT on the commit message. A message guard is unsafe here:
+# ci-apply.yml commits "[ci] apply-plugin-metadata-and-formatting" and
+# "[ci] apply-version-metadata" onto the PR BRANCH, so those routinely sit at
+# a PR branch's tip (see 7d8b18e, 2b1763a). Rebase merge is enabled on this
+# repo, and rebase-merging such a PR makes one of them main's head commit. A
+# message guard would then skip this whole job - the authoritative test run
+# included - on precisely the push that needs it most, because a rebase
+# rewrites the very shas ci-apply.yml stamped into the manifests.
 
 on:
   push:
@@ -55,14 +65,28 @@ permissions:
 
 jobs:
   build:
-    # See CONSEQUENCE in the header. Do not remove without first moving the
-    # pushes back to an identity whose commits do not trigger workflows.
-    if: ${{ !startsWith(github.event.head_commit.message, '[ci] ') }}
+    # See CONSEQUENCE in the header. Nothing but the auto-commit steps below
+    # commits as `plugman-ci`, so this skips this workflow's own pushes and
+    # nothing else. Do not remove without first moving the pushes back to an
+    # identity whose commits do not trigger workflows.
+    #
+    # The repository check keeps forks out of a job they cannot pass: they
+    # have no PAT, and their main is not authoritative for anything.
+    if: >-
+      github.repository == 'bombsquad-community/plugin-manager' &&
+      github.event.head_commit.committer.name != 'plugman-ci'
     runs-on: ubuntu-latest
     steps:
       # Fail fast and legibly. Without this, a missing secret surfaces as an
       # opaque authentication error at the first auto-commit step, five steps
       # later, which reads like a protection problem rather than a config one.
+      #
+      # Failing the whole job - tests included - is deliberate. With no PAT
+      # the metadata steps still run and the suite still passes, because both
+      # work on this runner's tree; the result would be a green check over a
+      # main whose committed manifests were never stamped. That is the exact
+      # trap ci-apply.yml's MERGE GATE comment describes. No signal beats a
+      # false one.
       - name: Check PAT is configured
         env:
           PAT: ${{ secrets.PAT }}
@@ -103,6 +127,9 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "[ci] apply-formatting"
+          # Identity the job-level `if:` keys on. See CONSEQUENCE in the header.
+          commit_user_name: "plugman-ci"
+          commit_user_email: "plugman-ci@users.noreply.github.com"
 
       # Resolved BEFORE any of the auto-commit steps below rewrite HEAD, so it
       # stays the tip main had when this push arrived. github.event.before is
@@ -158,6 +185,8 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "[ci] apply-plugin-metadata"
+          commit_user_name: "plugman-ci"
+          commit_user_email: "plugman-ci@users.noreply.github.com"
 
       - name: Apply Version Metadata
         run: |
@@ -167,6 +196,16 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "[ci] apply-version-metadata"
+          commit_user_name: "plugman-ci"
+          commit_user_email: "plugman-ci@users.noreply.github.com"
+
+      # Every push is done by this point. Drop the PAT from .git/config before
+      # handing control to the repo's own test suite, so that code cannot
+      # reach a credential that bypasses main's ruleset. Partial mitigation
+      # only: autopep8 and GitPython are unpinned and already ran above with
+      # the credential live.
+      - name: Drop push credentials
+        run: git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Execute Tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,18 @@ on:
     paths:
       - index.json
 
+# ci.yml's "[ci] apply-version-metadata" push is what fills the null entry in
+# index.json, so it matches the path filter above and starts a run of its own.
+# Under GITHUB_TOKEN that push started nothing; under a PAT it does, which can
+# put two runs of this workflow in flight for one release - both reading the
+# same "previous tag" and both trying to create the same new one. Serialising
+# them means the second sees the tag the first published and no-ops via
+# versioning_tools.py. Never cancel-in-progress: a cancelled run can leave a
+# tag created with no release attached to it.
+concurrency:
+  group: create-release
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Create Release


### PR DESCRIPTION
Two commits. The first makes `ci.yml` able to do its job at all; the second fixes problems the first one introduces.

## `fix require pr issue for ci` (f4eea3d)

`ci.yml` never ran `auto_apply_plugin_metadata.py`. A push that bumps a plugin's `plugman` version therefore landed the new bytes with no matching manifest entry, leaving the manifest advertising the OLD version's `md5sum`. The in-game manager verifies MD5 before installing, so every download of that plugin fails, and `test_latest_version` fails on that run and every later one. That is what `8628c97` (finder 1.0 to 4.1) did to main; it stayed broken until #485 reverted the change, restoring the old bytes rather than recording the new ones.

The commit adds the missing step, plus a `Resolve push base` step so the diff and `PLUGMAN_BASE_REF` are computed from `github.event.before` before any auto-commit rewrites HEAD.

It also switches the pushes from `GITHUB_TOKEN` to `secrets.PAT`. `ci.yml` currently cannot push to main at all:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

That is a protection-rule rejection rather than a permissions one, so no `permissions:` value fixes it, and `GITHUB_TOKEN` cannot be given a ruleset bypass (bypass actors are repository roles, teams, installed Apps or Dependabot). The PAT account sits on the bypass list instead. `GITHUB_TOKEN` is dropped to `contents: read`.

## `key the self-trigger guard on committer identity` (f3575ca)

Unlike `GITHUB_TOKEN`, a PAT's pushes start new workflow runs, so the job must skip its own commits. The first commit did that by matching the `[ci] ` message prefix. That is unsafe: `ci-apply.yml` commits `[ci] apply-version-metadata` and `[ci] apply-plugin-metadata-and-formatting` **onto the PR branch**, so those routinely sit at a PR branch's tip (`7d8b18e`, `2b1763a`). Rebase merge is enabled here, so rebase-merging an ordinary PR makes one of them main's head commit and skips the entire job, including the authoritative strict `test_versions` run. That is the worst possible push to skip, because a rebase rewrites the very shas `ci-apply.yml` stamped into the manifests.

The three auto-commit steps now commit as `plugman-ci` and the guard keys on that. Nothing else uses that identity, so it skips this workflow's own pushes and nothing more; `ci-apply.yml`'s commits reaching main now get a full run. Squash merge was never affected, since `COMMIT_OR_PR_TITLE` resolves to the PR title on a multi-commit branch.

Also in `ci.yml`:

- Skip the job on forks. They have no PAT and only ever fail at the preflight.
- Record why the missing-PAT preflight fails the whole job instead of letting the tests run. Without a PAT the metadata steps and the suite both still pass against the runner's tree, so the run goes green over a main whose committed manifests were never stamped. That is the trap `ci-apply.yml`'s MERGE GATE comment describes.
- Reset the remote URL after the last push so the test suite cannot reach a ruleset-bypassing credential. Partial mitigation only, and the comment says so: `autopep8` and `GitPython` are unpinned and already ran with it live.

`release.yml` gets a `concurrency` group for the same root cause. It filters on `paths: [index.json]`, exactly what `[ci] apply-version-metadata` rewrites, so under a PAT that push now starts a release run of its own. Two runs for one release read the same previous tag and both try to create it. Serialised, the second sees the published tag and no-ops through `versioning_tools.py`. Never `cancel-in-progress`: a cancelled run can leave a tag with no release attached.

## Before merging

- `secrets.PAT` predates this work (created 2022-08-31, never rotated, referenced nowhere else). Confirm it is still valid and that its owner can bypass ruleset 22381346. That ruleset's existing bypass is `RepositoryRole:5` (repository admin), so an admin's token needs no new entry; a non-admin's does.
- Worth replacing it with a fine-grained token scoped to this repo. A 2022-era classic PAT carries `repo` scope across every repo its owner can reach.

## Testing

No test covers workflow files. The plugin-metadata step was validated by replaying five synthetic cases (version bump stamps the manifest and 21 tests pass; no bump fails loudly; non-plugin push no-ops; deletions are filtered out by `--diff-filter=d`; a new plugin gets an entry) and eight real historical merges, seven of which were clean no-ops. Both files parse as YAML and the step order is unchanged apart from the additions described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDSzHqhTmdMMD8f3UF6eNo